### PR TITLE
replaced dashes to underscores in filter names also. More refactoring…

### DIFF
--- a/exopite-simple-options/exopite-simple-options-framework-class.php
+++ b/exopite-simple-options/exopite-simple-options-framework-class.php
@@ -1248,7 +1248,7 @@ if ( ! class_exists( 'Exopite_Simple_Options_Framework' ) ) :
 
 			do_action( 'exopite_sof_after_generate_field', $field, $this->config );
 
-			echo apply_filters( 'exopite_sof_add_field ', $output, $field, $this->config );
+			echo apply_filters( 'exopite_sof_add_field', $output, $field, $this->config );
 
 			do_action( 'exopite_sof_after_add_field', $field, $this->config );
 
@@ -1337,11 +1337,11 @@ if ( ! class_exists( 'Exopite_Simple_Options_Framework' ) ) :
 
 			switch ( $this->config['type'] ) {
 				case 'menu':
-					add_action( 'exopite-simple-options-framework-display-page-header', array(
+					add_action( 'exopite_sof_display_page_header', array(
 						$this,
 						'display_options_page_header'
 					), 10, 1 );
-					do_action( 'exopite_simple_options_framework_display_page_header', $this->config );
+					do_action( 'exopite_sof_display_page_header', $this->config );
 					break;
 
 				case 'metabox':


### PR DESCRIPTION
Following are done:
1. dashes to underscores in hooks names
2. $config gets default values in set_properties() method so that we dont have to chanck for isset() for all properties
3. plugin_action_links refactored to include "settings" link by default, user can set 'settings_link' to false to disable it
4. default config array for menu and metabox are using filters and coming from method to make it more modular